### PR TITLE
Add the Limiter and LimitedTransport types

### DIFF
--- a/json.go
+++ b/json.go
@@ -26,7 +26,7 @@ type (
 //
 // The signature of the function is:
 //
-//   func(context.Context, inType) (outType, error)
+//	func(context.Context, inType) (outType, error)
 //
 // where inType is any type that can be decoded from JSON
 // and outType is any type that can be encoded to JSON.

--- a/limit.go
+++ b/limit.go
@@ -1,0 +1,34 @@
+package mid
+
+import (
+	"context"
+	"net/http"
+)
+
+// Limiter is the type of an object that can be used to limit the rate of some operation.
+// Calling Wait on a Limiter blocks until the operation is allowed to proceed.
+//
+// This interface is satisfied by the *Limiter type in golang.org/x/time/rate.
+type Limiter interface {
+	Wait(context.Context) error
+}
+
+// LimitedTransport is an http.RoundTripper that limits the rate of requests it makes using a [Limiter].
+// After waiting for the limiter in L, it delegates to the http.RoundTripper in T.
+// If T is nil, it uses [http.DefaultTransport].
+type LimitedTransport struct {
+	L Limiter
+	T http.RoundTripper
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+func (lt LimitedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := lt.L.Wait(req.Context()); err != nil {
+		return nil, err
+	}
+	next := lt.T
+	if next == nil {
+		next = http.DefaultTransport
+	}
+	return next.RoundTrip(req)
+}


### PR DESCRIPTION
This PR adds `Limiter`, an interface that abstracts `*"golang.org/x/time/rate".Limiter`, and `LimitedTransport`, which can be used in an HTTP client to limit the rate of requests it makes.